### PR TITLE
feat: add auth foundation and dev-cluster deployment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,6 @@
     5000,
     5001
   ],
-  "postCreateCommand": "bash -lc 'dotnet restore TextRpg.slnx && cd frontend && if [ -f package-lock.json ]; then npm ci; else npm install --package-lock=false; fi'",
+  "postCreateCommand": "bash -lc 'dotnet restore TextRpg.slnx && dotnet tool restore && cd frontend && if [ -f package-lock.json ]; then npm ci; else npm install --package-lock=false; fi'",
   "remoteUser": "vscode"
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.devcontainer
+frontend/node_modules
+frontend/dist
+**/bin
+**/obj
+**/.DS_Store
+**/*.user
+**/*.suo
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,158 @@
-name: Deploy Dispatcher
+name: Deploy to dev-cluster
 
 on:
   push:
     branches:
-      - main        
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      NAMESPACE: text-rpg
+      FRONTEND_HOST: text-rpg.dev.sakuraya.cloud
     steps:
       - uses: actions/checkout@v4
+
+      - name: Derive image metadata
+        id: vars
+        run: |
+          echo "image_owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/frontend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-frontend:${{ steps.vars.outputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-frontend:main
+
+      - name: Build and push BFF image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/dotnet-web.Dockerfile
+          build-args: |
+            PROJECT_PATH=src/BffGateway/BffGateway.Service/BffGateway.Service.csproj
+            APP_DLL=BffGateway.Service.dll
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-bffgateway:${{ steps.vars.outputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-bffgateway:main
+
+      - name: Build and push Core Backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/dotnet-web.Dockerfile
+          build-args: |
+            PROJECT_PATH=src/CoreBackend/CoreBackend.Service/CoreBackend.Service.csproj
+            APP_DLL=CoreBackend.Service.dll
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-corebackend:${{ steps.vars.outputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-corebackend:main
+
+      - name: Build and push AI Orchestrator image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/dotnet-web.Dockerfile
+          build-args: |
+            PROJECT_PATH=src/AIOrchestrator/AIOrchestrator.Service/AIOrchestrator.Service.csproj
+            APP_DLL=AIOrchestrator.Service.dll
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-aiorchestrator:${{ steps.vars.outputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-aiorchestrator:main
+
+      - name: Build and push Jobs image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/dotnet-worker.Dockerfile
+          build-args: |
+            PROJECT_PATH=src/Jobs/Jobs.Service/Jobs.Service.csproj
+            APP_DLL=Jobs.Service.dll
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-jobs:${{ steps.vars.outputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-jobs:main
+
       - name: Tailscale
         uses: tailscale/github-action@v2
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
-      - run: tailscale configure kubeconfig text-rpg-cluster
+
+      - name: Configure kubeconfig
+        run: tailscale configure kubeconfig dev-cluster
+
+      - name: Install envsubst
+        run: sudo apt-get update && sudo apt-get install -y gettext-base
+
+      - name: Create namespace
+        run: kubectl apply -f deploy/k8s/namespace.yaml
+
+      - name: Sync application secrets
+        env:
+          AUTH_BOOTSTRAP_EMAIL: ${{ secrets.AUTH_BOOTSTRAP_EMAIL }}
+          AUTH_BOOTSTRAP_PASSWORD: ${{ secrets.AUTH_BOOTSTRAP_PASSWORD }}
+          AUTH_BOOTSTRAP_DISPLAY_NAME: ${{ secrets.AUTH_BOOTSTRAP_DISPLAY_NAME }}
+          AUTH_GOOGLE_CLIENT_ID: ${{ secrets.AUTH_GOOGLE_CLIENT_ID }}
+          AUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.AUTH_GOOGLE_CLIENT_SECRET }}
+          AUTH_MICROSOFT_CLIENT_ID: ${{ secrets.AUTH_MICROSOFT_CLIENT_ID }}
+          AUTH_MICROSOFT_CLIENT_SECRET: ${{ secrets.AUTH_MICROSOFT_CLIENT_SECRET }}
+        run: |
+          kubectl -n "$NAMESPACE" create secret generic text-rpg-secrets \
+            --from-literal=bootstrap-email="${AUTH_BOOTSTRAP_EMAIL}" \
+            --from-literal=bootstrap-password="${AUTH_BOOTSTRAP_PASSWORD}" \
+            --from-literal=bootstrap-display-name="${AUTH_BOOTSTRAP_DISPLAY_NAME}" \
+            --from-literal=google-client-id="${AUTH_GOOGLE_CLIENT_ID}" \
+            --from-literal=google-client-secret="${AUTH_GOOGLE_CLIENT_SECRET}" \
+            --from-literal=microsoft-client-id="${AUTH_MICROSOFT_CLIENT_ID}" \
+            --from-literal=microsoft-client-secret="${AUTH_MICROSOFT_CLIENT_SECRET}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy manifests
+        env:
+          FRONTEND_IMAGE: ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-frontend:${{ steps.vars.outputs.image_tag }}
+          BFF_IMAGE: ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-bffgateway:${{ steps.vars.outputs.image_tag }}
+          COREBACKEND_IMAGE: ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-corebackend:${{ steps.vars.outputs.image_tag }}
+          AIORCHESTRATOR_IMAGE: ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-aiorchestrator:${{ steps.vars.outputs.image_tag }}
+          JOBS_IMAGE: ghcr.io/${{ steps.vars.outputs.image_owner }}/text-rpg-jobs:${{ steps.vars.outputs.image_tag }}
+        run: envsubst < deploy/k8s/dev/manifests.yaml | kubectl apply -f -
+
+      - name: Wait for rollout
+        run: |
+          kubectl -n "$NAMESPACE" rollout status deployment/frontend --timeout=180s
+          kubectl -n "$NAMESPACE" rollout status deployment/bffgateway --timeout=180s
+          kubectl -n "$NAMESPACE" rollout status deployment/corebackend --timeout=180s
+          kubectl -n "$NAMESPACE" rollout status deployment/aiorchestrator --timeout=180s
+          kubectl -n "$NAMESPACE" rollout status deployment/jobs --timeout=180s

--- a/README.md
+++ b/README.md
@@ -49,7 +49,61 @@ AIとユーザーが共同で物語を進行・編集できる
 
 - VS Code / GitHub Codespaces では `.devcontainer/` を利用できます
 - devcontainer には **.NET 10 SDK**, **Node.js 20**, **protobuf-compiler** を含めています
-- 初回作成時に `dotnet restore TextRpg.slnx` と `frontend/` の npm 依存解決を自動実行します
+- 初回作成時に `dotnet restore TextRpg.slnx`、`dotnet tool restore`、`frontend/` の npm 依存解決を自動実行します
+- Aspire CLI はプロジェクトローカル tool として追加済みで、`dotnet aspire` または `dotnet tool run aspire` で利用できます
+- `dotnet aspire run --apphost src/AppHost/AppHost.csproj` で backend 群に加えて Vite frontend も起動します
+- Aspire 起動時の dashboard / frontend / BFF ポートは固定せず自動割り当てします
+- Coder の port forward 経由でも開けるように、frontend は `*.coder.dev.sakuraya.cloud` を Vite の許可ホストに含めています
+- 各 .NET service は OTLP exporter が与えられたときに OpenTelemetry（ログ / トレース / メトリクス）を Aspire dashboard へ送信します
+
+### GitHub Actions / dev-cluster デプロイ
+
+- `.github/workflows/main.yml` で `main` push または `workflow_dispatch` 時に `dev-cluster` へデプロイします
+- デプロイ先 namespace は `text-rpg` です
+- frontend ingress host は `text-rpg.dev.sakuraya.cloud` です
+- GitHub Actions は GHCR に以下の image を push してから Kubernetes manifest を適用します
+  - `text-rpg-frontend`
+  - `text-rpg-bffgateway`
+  - `text-rpg-corebackend`
+  - `text-rpg-aiorchestrator`
+  - `text-rpg-jobs`
+- デプロイに必要な GitHub Secrets
+  - `TS_OAUTH_CLIENT_ID`
+  - `TS_OAUTH_SECRET`
+  - `AUTH_BOOTSTRAP_EMAIL`
+  - `AUTH_BOOTSTRAP_PASSWORD`
+  - `AUTH_BOOTSTRAP_DISPLAY_NAME`（任意）
+  - `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET`（任意）
+  - `AUTH_MICROSOFT_CLIENT_ID` / `AUTH_MICROSOFT_CLIENT_SECRET`（任意）
+
+### 認証の最小構成
+
+BFF Gateway では、**環境変数でメール/パスワードの初期ログイン**と **OAuth ログイン**を有効化できます。
+
+#### メール/パスワード
+
+- `AUTH_BOOTSTRAP_EMAIL`
+- `AUTH_BOOTSTRAP_PASSWORD`
+- `AUTH_BOOTSTRAP_DISPLAY_NAME`（任意）
+
+この 2 つ以上を設定すると、起動時に bootstrap ユーザーとしてログイン可能になります。
+
+#### OAuth
+
+- Google
+  - `AUTH_GOOGLE_CLIENT_ID`
+  - `AUTH_GOOGLE_CLIENT_SECRET`
+  - `AUTH_GOOGLE_DISPLAY_NAME`（任意）
+- Microsoft Account
+  - `AUTH_MICROSOFT_CLIENT_ID`
+  - `AUTH_MICROSOFT_CLIENT_SECRET`
+  - `AUTH_MICROSOFT_DISPLAY_NAME`（任意）
+
+#### フロントエンド連携
+
+- `AUTH_FRONTEND_URL` : OAuth 完了後のリダイレクト先。既定値は `http://localhost:5173`
+- `AUTH_ALLOWED_ORIGINS` : Cookie 付き API 呼び出しを許可する origin のカンマ区切り一覧
+- `VITE_BFF_BASE_URL` : frontend から呼ぶ BFF のベース URL。既定値は `http://localhost:5000`
 
 ### バックエンド
 - ASP.NET Core (gRPC)

--- a/deploy/docker/dotnet-web.Dockerfile
+++ b/deploy/docker/dotnet-web.Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+ARG PROJECT_PATH
+
+WORKDIR /src
+COPY . .
+
+RUN dotnet restore "$PROJECT_PATH"
+RUN dotnet publish "$PROJECT_PATH" --configuration Release --no-restore --output /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+
+ARG APP_DLL
+ENV APP_DLL=$APP_DLL
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+
+WORKDIR /app
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "dotnet \"$APP_DLL\""]
+

--- a/deploy/docker/dotnet-worker.Dockerfile
+++ b/deploy/docker/dotnet-worker.Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+ARG PROJECT_PATH
+
+WORKDIR /src
+COPY . .
+
+RUN dotnet restore "$PROJECT_PATH"
+RUN dotnet publish "$PROJECT_PATH" --configuration Release --no-restore --output /app/publish
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+
+ARG APP_DLL
+ENV APP_DLL=$APP_DLL
+
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["sh", "-c", "dotnet \"$APP_DLL\""]
+

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS build
+
+WORKDIR /src/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY deploy/docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /src/frontend/dist /usr/share/nginx/html
+
+EXPOSE 8080
+

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+

--- a/deploy/k8s/dev/manifests.yaml
+++ b/deploy/k8s/dev/manifests.yaml
@@ -1,0 +1,262 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ${FRONTEND_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bffgateway
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bffgateway
+  template:
+    metadata:
+      labels:
+        app: bffgateway
+    spec:
+      containers:
+        - name: bffgateway
+          image: ${BFF_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://0.0.0.0:8080
+            - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+              value: "true"
+            - name: AUTH_FRONTEND_URL
+              value: https://${FRONTEND_HOST}
+            - name: AUTH_ALLOWED_ORIGINS
+              value: https://${FRONTEND_HOST}
+            - name: AUTH_BOOTSTRAP_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: bootstrap-email
+                  optional: true
+            - name: AUTH_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: bootstrap-password
+                  optional: true
+            - name: AUTH_BOOTSTRAP_DISPLAY_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: bootstrap-display-name
+                  optional: true
+            - name: AUTH_GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: google-client-id
+                  optional: true
+            - name: AUTH_GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: google-client-secret
+                  optional: true
+            - name: AUTH_MICROSOFT_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: microsoft-client-id
+                  optional: true
+            - name: AUTH_MICROSOFT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: text-rpg-secrets
+                  key: microsoft-client-secret
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bffgateway
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: bffgateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebackend
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: corebackend
+  template:
+    metadata:
+      labels:
+        app: corebackend
+    spec:
+      containers:
+        - name: corebackend
+          image: ${COREBACKEND_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://0.0.0.0:8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebackend
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: corebackend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aiorchestrator
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aiorchestrator
+  template:
+    metadata:
+      labels:
+        app: aiorchestrator
+    spec:
+      containers:
+        - name: aiorchestrator
+          image: ${AIORCHESTRATOR_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://0.0.0.0:8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aiorchestrator
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: aiorchestrator
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jobs
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jobs
+  template:
+    metadata:
+      labels:
+        app: jobs
+    spec:
+      containers:
+        - name: jobs
+          image: ${JOBS_IMAGE}
+          imagePullPolicy: Always
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: text-rpg
+  namespace: ${NAMESPACE}
+spec:
+  rules:
+    - host: ${FRONTEND_HOST}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: bffgateway
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: text-rpg
+

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "aspire.cli": {
+      "version": "13.2.2",
+      "commands": [
+        "aspire"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,294 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+
+type OAuthProvider = {
+  id: string
+  displayName: string
+}
+
+type AuthProvidersResponse = {
+  passwordLoginEnabled: boolean
+  oauthProviders: OAuthProvider[]
+}
+
+type RawAuthProvidersResponse = {
+  passwordLoginEnabled: boolean
+  oauthProviders?: OAuthProvider[]
+  oAuthProviders?: OAuthProvider[]
+}
+
+type AuthUser = {
+  userId: string
+  displayName: string
+  email?: string
+  provider: string
+}
+
+type AuthStateResponse = {
+  authenticated: boolean
+  user: AuthUser | null
+}
+
+type LoginFormState = {
+  email: string
+  password: string
+}
+
+const configuredApiBaseUrl = (import.meta.env.VITE_BFF_BASE_URL as string | undefined)?.replace(/\/$/, '')
+const apiBaseUrl = configuredApiBaseUrl && configuredApiBaseUrl.length > 0 ? configuredApiBaseUrl : ''
+
 function App() {
+  const [providers, setProviders] = useState<AuthProvidersResponse | null>(null)
+  const [authState, setAuthState] = useState<AuthStateResponse>({ authenticated: false, user: null })
+  const [loginForm, setLoginForm] = useState<LoginFormState>({ email: '', password: '' })
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const authStatusFromUrl = useMemo(() => {
+    const params = new URLSearchParams(window.location.search)
+    const auth = params.get('auth')
+    const provider = params.get('provider')
+    const authMessage = params.get('message')
+
+    if (!auth) {
+      return null
+    }
+
+    if (auth === 'success') {
+      return `${provider ?? 'OAuth'} でログインしました。`
+    }
+
+    return authMessage ?? `${provider ?? 'OAuth'} ログインに失敗しました。`
+  }, [])
+
+  useEffect(() => {
+    if (!authStatusFromUrl) {
+      return
+    }
+
+    if (window.location.search.includes('auth=success')) {
+      setMessage(authStatusFromUrl)
+    } else {
+      setError(authStatusFromUrl)
+    }
+
+    window.history.replaceState({}, document.title, window.location.pathname)
+  }, [authStatusFromUrl])
+
+  useEffect(() => {
+    void loadAuthState()
+  }, [])
+
+  function normalizeProvidersResponse(response: RawAuthProvidersResponse): AuthProvidersResponse {
+    return {
+      passwordLoginEnabled: response.passwordLoginEnabled,
+      oauthProviders: response.oauthProviders ?? response.oAuthProviders ?? [],
+    }
+  }
+
+  async function loadAuthState() {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [providersResponse, meResponse] = await Promise.all([
+        fetch(`${apiBaseUrl}/api/auth/providers`, { credentials: 'include' }),
+        fetch(`${apiBaseUrl}/api/auth/me`, { credentials: 'include' }),
+      ])
+
+      if (!providersResponse.ok) {
+        throw new Error('認証プロバイダ設定の取得に失敗しました。')
+      }
+
+      if (!meResponse.ok) {
+        throw new Error('ログイン状態の取得に失敗しました。')
+      }
+
+      setProviders(normalizeProvidersResponse((await providersResponse.json()) as RawAuthProvidersResponse))
+      setAuthState((await meResponse.json()) as AuthStateResponse)
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : '認証情報の読み込みに失敗しました。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handlePasswordLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    setMessage(null)
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/auth/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(loginForm),
+      })
+
+      if (!response.ok) {
+        const body = (await response.json()) as { message?: string }
+        throw new Error(body.message ?? 'ログインに失敗しました。')
+      }
+
+      setAuthState((await response.json()) as AuthStateResponse)
+      setMessage('メール/パスワードでログインしました。')
+      setLoginForm(current => ({ ...current, password: '' }))
+    } catch (loginError) {
+      setError(loginError instanceof Error ? loginError.message : 'ログインに失敗しました。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleLogout() {
+    setSubmitting(true)
+    setError(null)
+    setMessage(null)
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/auth/logout`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+
+      if (!response.ok && response.status !== 204) {
+        throw new Error('ログアウトに失敗しました。')
+      }
+
+      setAuthState({ authenticated: false, user: null })
+      setMessage('ログアウトしました。')
+    } catch (logoutError) {
+      setError(logoutError instanceof Error ? logoutError.message : 'ログアウトに失敗しました。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function beginOAuthLogin(provider: OAuthProvider) {
+    const returnUrl = window.location.pathname || '/'
+    window.location.href = `${apiBaseUrl}/api/auth/oauth/${encodeURIComponent(provider.id)}?returnUrl=${encodeURIComponent(returnUrl)}`
+  }
+
   return (
-    <div>
-      <h1>AI Text RPG Platform</h1>
-      <p>AIとユーザーが共同で物語を進行・編集できるWebベースのテキストRPGプラットフォームです。</p>
-    </div>
+    <main className="app-shell">
+      <section className="hero-card">
+        <p className="eyebrow">TextRpg Auth Foundation</p>
+        <h1>AI Text RPG Platform</h1>
+        <p className="description">
+          AIとユーザーが共同で物語を進行・編集できるWebベースのテキストRPGプラットフォームです。
+          まずは認証基盤として、メール/パスワードと OAuth ログインを利用できます。
+        </p>
+        <div className="status-row">
+          <span className="status-label">BFF</span>
+          <code>{apiBaseUrl}</code>
+        </div>
+
+        {message ? <p className="notice success">{message}</p> : null}
+        {error ? <p className="notice error">{error}</p> : null}
+      </section>
+
+      <section className="auth-card">
+        <header>
+          <h2>ログイン</h2>
+          <p>環境変数で有効化された認証方式だけ表示されます。</p>
+        </header>
+
+        {loading || !providers ? (
+          <p>認証設定を読み込み中です...</p>
+        ) : authState.authenticated && authState.user ? (
+          <div className="signed-in-panel">
+            <h3>ログイン中</h3>
+            <dl>
+              <div>
+                <dt>表示名</dt>
+                <dd>{authState.user.displayName}</dd>
+              </div>
+              <div>
+                <dt>メール</dt>
+                <dd>{authState.user.email ?? '未提供'}</dd>
+              </div>
+              <div>
+                <dt>プロバイダ</dt>
+                <dd>{authState.user.provider}</dd>
+              </div>
+              <div>
+                <dt>ユーザーID</dt>
+                <dd>{authState.user.userId}</dd>
+              </div>
+            </dl>
+
+            <button type="button" onClick={handleLogout} disabled={submitting}>
+              ログアウト
+            </button>
+          </div>
+        ) : (
+          <>
+            {providers.passwordLoginEnabled ? (
+              <form className="login-form" onSubmit={handlePasswordLogin}>
+                <label>
+                  Email
+                  <input
+                    autoComplete="email"
+                    type="email"
+                    value={loginForm.email}
+                    onChange={event => setLoginForm(current => ({ ...current, email: event.target.value }))}
+                    placeholder="user@example.com"
+                    required
+                  />
+                </label>
+
+                <label>
+                  Password
+                  <input
+                    autoComplete="current-password"
+                    type="password"
+                    value={loginForm.password}
+                    onChange={event => setLoginForm(current => ({ ...current, password: event.target.value }))}
+                    placeholder="password"
+                    required
+                  />
+                </label>
+
+                <button type="submit" disabled={submitting}>
+                  メール/パスワードでログイン
+                </button>
+              </form>
+            ) : (
+              <p className="helper-text">
+                メール/パスワードログインは未設定です。AUTH_BOOTSTRAP_EMAIL と AUTH_BOOTSTRAP_PASSWORD を設定してください。
+              </p>
+            )}
+
+            <div className="oauth-section">
+              <h3>OAuth ログイン</h3>
+              {providers.oauthProviders.length > 0 ? (
+                <div className="oauth-actions">
+                  {providers.oauthProviders.map(provider => (
+                    <button
+                      key={provider.id}
+                      type="button"
+                      className="secondary"
+                      onClick={() => beginOAuthLogin(provider)}
+                    >
+                      {provider.displayName} でログイン
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="helper-text">
+                  OAuth プロバイダは未設定です。AUTH_GOOGLE_* または AUTH_MICROSOFT_* を設定してください。
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </main>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,15 +2,169 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  color: #e5eef7;
+  background: #0f172a;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 30%),
+    #0f172a;
 }
 
 #root {
-  max-width: 1280px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 2rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card,
+.auth-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.8);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #93c5fd;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+.description,
+.auth-card > header > p,
+.helper-text {
+  color: #cbd5e1;
+}
+
+.status-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.status-label {
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  font-size: 0.85rem;
+}
+
+code {
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.35rem;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.notice {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.notice.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #bbf7d0;
+}
+
+.notice.error {
+  background: rgba(248, 113, 113, 0.16);
+  color: #fecaca;
+}
+
+.login-form,
+.signed-in-panel,
+.oauth-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.login-form label {
+  display: grid;
+  gap: 0.4rem;
+  color: #e2e8f0;
+}
+
+.login-form input {
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: #f8fafc;
+}
+
+.login-form button,
+.signed-in-panel button,
+.oauth-actions button {
+  border: 0;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #eff6ff;
+}
+
+.oauth-actions button.secondary {
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.login-form button:disabled,
+.signed-in-panel button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.oauth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.signed-in-panel dl {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.signed-in-panel dt {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.signed-in-panel dd {
+  margin: 0.2rem 0 0;
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,15 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.coder.dev.sakuraya.cloud'],
+    proxy: {
+      '/api': {
+        target: process.env.BFF_PROXY_TARGET ?? process.env.VITE_BFF_BASE_URL ?? 'http://localhost:5000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })

--- a/src/AIOrchestrator/AIOrchestrator.Service/Program.cs
+++ b/src/AIOrchestrator/AIOrchestrator.Service/Program.cs
@@ -3,6 +3,7 @@ using TextRpg.Shared.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddTextRpgTelemetry();
 builder.Services.AddGrpc(options => options.EnableDetailedErrors = builder.Environment.IsDevelopment());
 
 var app = builder.Build();

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -1,27 +1,23 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.2.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AspireComponentGroup>AppHost</AspireComponentGroup>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.2" />
+    <ProjectReference Include="..\AIOrchestrator\AIOrchestrator.Service\AIOrchestrator.Service.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\BffGateway\BffGateway.Service\BffGateway.Service.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\CoreBackend\CoreBackend.Service\CoreBackend.Service.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\Jobs\Jobs.Service\Jobs.Service.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\LocalGateway\LocalGateway.Service\LocalGateway.Service.csproj" IsAspireProjectResource="true" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AIOrchestrator\AIOrchestrator.Service\AIOrchestrator.Service.csproj"
-                      IsAspireProjectResource="true" />
-    <ProjectReference Include="..\BffGateway\BffGateway.Service\BffGateway.Service.csproj"
-                      IsAspireProjectResource="true" />
-    <ProjectReference Include="..\CoreBackend\CoreBackend.Service\CoreBackend.Service.csproj"
-                      IsAspireProjectResource="true" />
-    <ProjectReference Include="..\Jobs\Jobs.Service\Jobs.Service.csproj"
-                      IsAspireProjectResource="true" />
-    <ProjectReference Include="..\LocalGateway\LocalGateway.Service\LocalGateway.Service.csproj"
-                      IsAspireProjectResource="true" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.2" />
   </ItemGroup>
 
 </Project>

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,15 +1,57 @@
+using Aspire.Hosting.JavaScript;
+using System.Net;
+using System.Net.Sockets;
+
+EnsureAspireDashboardDefaults();
+
 var builder = DistributedApplication.CreateBuilder(args);
 
-var aiOrchestrator = builder.AddProject<Projects.AIOrchestrator_Service>("aiorchestrator");
+var aiOrchestrator = builder.AddProject<Projects.AIOrchestrator_Service>("aiorchestrator")
+    .WithHttpEndpoint(env: "ASPNETCORE_HTTP_PORTS")
+    .AsHttp2Service();
 var localGateway = builder.AddProject<Projects.LocalGateway_Service>("localgateway");
 var jobs = builder.AddProject<Projects.Jobs_Service>("jobs")
     .WithReference(localGateway);
 var coreBackend = builder.AddProject<Projects.CoreBackend_Service>("corebackend")
+    .WithHttpEndpoint(env: "ASPNETCORE_HTTP_PORTS")
+    .AsHttp2Service()
     .WithReference(aiOrchestrator)
     .WithReference(jobs);
-
-builder.AddProject<Projects.BffGateway_Service>("bffgateway")
+var bffGateway = builder.AddProject<Projects.BffGateway_Service>("bffgateway")
+    .WithHttpEndpoint(env: "ASPNETCORE_HTTP_PORTS")
+    .WithExternalHttpEndpoints()
     .WithReference(coreBackend)
     .WithReference(aiOrchestrator);
+var frontend = builder.AddViteApp("frontend", Path.Combine("..", "..", "frontend"))
+    .WithExternalHttpEndpoints()
+    .WithReference(bffGateway)
+    .WithEnvironment("BFF_PROXY_TARGET", bffGateway.GetEndpoint("http"));
+
+bffGateway
+    .WithEnvironment("AUTH_FRONTEND_URL", frontend.GetEndpoint("http"))
+    .WithEnvironment("AUTH_ALLOWED_ORIGINS", frontend.GetEndpoint("http"));
 
 builder.Build().Run();
+
+static void EnsureAspireDashboardDefaults()
+{
+    SetIfMissing("ASPIRE_ALLOW_UNSECURED_TRANSPORT", "true");
+    SetIfMissing("ASPNETCORE_URLS", $"http://127.0.0.1:{GetAvailablePort()}");
+    SetIfMissing("ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", $"http://127.0.0.1:{GetAvailablePort()}");
+    SetIfMissing("ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL", $"http://127.0.0.1:{GetAvailablePort()}");
+
+    static void SetIfMissing(string key, string value)
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(key)))
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    static int GetAvailablePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}

--- a/src/BffGateway/BffGateway.Service/Auth/AuthEndpoints.cs
+++ b/src/BffGateway/BffGateway.Service/Auth/AuthEndpoints.cs
@@ -1,0 +1,150 @@
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace BffGateway.Service.Auth;
+
+public static class AuthEndpoints
+{
+    public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/auth");
+
+        group.MapGet("/providers", (BffAuthOptions authOptions) =>
+        {
+            var response = new AuthProvidersResponse(
+                authOptions.IsPasswordLoginEnabled,
+                authOptions.EnabledOAuthProviders
+                    .Select(provider => new OAuthProviderResponse(provider.Id, provider.DisplayName))
+                    .ToArray());
+
+            return Results.Ok(response);
+        });
+
+        group.MapGet("/me", (ClaimsPrincipal user) =>
+        {
+            var response = user.Identity?.IsAuthenticated == true
+                ? new AuthStateResponse(
+                    true,
+                    new AuthUserResponse(
+                        user.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty,
+                        user.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
+                        user.FindFirstValue(ClaimTypes.Email),
+                        user.FindFirstValue(AuthPrincipalFactory.ProviderClaimType) ?? BffAuthOptions.PasswordProvider))
+                : new AuthStateResponse(false, null);
+
+            return Results.Ok(response);
+        });
+
+        group.MapPost("/login", async (PasswordLoginRequest? request, HttpContext context, BootstrapPasswordLoginService loginService, BffAuthOptions authOptions) =>
+        {
+            if (!loginService.IsEnabled)
+            {
+                return Results.Problem(
+                    statusCode: StatusCodes.Status503ServiceUnavailable,
+                    title: "Password login is not configured.",
+                    detail: "Set AUTH_BOOTSTRAP_EMAIL and AUTH_BOOTSTRAP_PASSWORD to enable password login.");
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["email"] = ["Email is required."],
+                    ["password"] = ["Password is required."]
+                });
+            }
+
+            if (!loginService.Validate(request.Email, request.Password))
+            {
+                return Results.Json(new ErrorResponse("メールアドレスまたはパスワードが正しくありません。"), statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            await context.SignInAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                AuthPrincipalFactory.CreateBootstrapPrincipal(authOptions));
+
+            return Results.Ok(new AuthStateResponse(
+                true,
+                new AuthUserResponse(
+                    $"bootstrap:{authOptions.Bootstrap.Email!.ToLowerInvariant()}",
+                    authOptions.Bootstrap.DisplayName,
+                    authOptions.Bootstrap.Email,
+                    BffAuthOptions.PasswordProvider)));
+        });
+
+        group.MapPost("/logout", async (HttpContext context) =>
+        {
+            await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return Results.NoContent();
+        });
+
+        group.MapGet("/oauth/{provider}", (string provider, string? returnUrl, BffAuthOptions authOptions) =>
+        {
+            if (!authOptions.TryGetOAuthProvider(provider, out _))
+            {
+                return Results.NotFound(new ErrorResponse($"OAuth provider '{provider}' is not configured."));
+            }
+
+            var sanitizedReturnUrl = BffAuthOptions.SanitizeReturnPath(returnUrl);
+            var properties = new AuthenticationProperties
+            {
+                RedirectUri = $"/api/auth/oauth/post-login?provider={Uri.EscapeDataString(provider)}&returnUrl={Uri.EscapeDataString(sanitizedReturnUrl)}"
+            };
+            properties.Items["returnUrl"] = sanitizedReturnUrl;
+
+            return Results.Challenge(properties, [provider]);
+        });
+
+        group.MapGet("/oauth/post-login", (string provider, string? returnUrl, ClaimsPrincipal user, BffAuthOptions authOptions) =>
+        {
+            var sanitizedReturnUrl = BffAuthOptions.SanitizeReturnPath(returnUrl);
+
+            if (user.Identity?.IsAuthenticated != true)
+            {
+                return Results.Redirect(authOptions.BuildFrontendRedirect(sanitizedReturnUrl, new Dictionary<string, string?>
+                {
+                    ["auth"] = "error",
+                    ["provider"] = provider,
+                    ["message"] = "OAuth login did not complete."
+                }));
+            }
+
+            return Results.Redirect(authOptions.BuildFrontendRedirect(sanitizedReturnUrl, new Dictionary<string, string?>
+            {
+                ["auth"] = "success",
+                ["provider"] = provider
+            }));
+        });
+
+        group.MapGet("/oauth/error", (string provider, string? returnUrl, string? message, BffAuthOptions authOptions) =>
+        {
+            var sanitizedReturnUrl = BffAuthOptions.SanitizeReturnPath(returnUrl);
+
+            return Results.Redirect(authOptions.BuildFrontendRedirect(sanitizedReturnUrl, new Dictionary<string, string?>
+            {
+                ["auth"] = "error",
+                ["provider"] = provider,
+                ["message"] = message ?? "OAuth login failed."
+            }));
+        });
+
+        return endpoints;
+    }
+
+    private sealed record AuthProvidersResponse(
+        bool PasswordLoginEnabled,
+        [property: JsonPropertyName("oauthProviders")]
+        IReadOnlyList<OAuthProviderResponse> OAuthProviders);
+
+    private sealed record OAuthProviderResponse(string Id, string DisplayName);
+
+    private sealed record AuthStateResponse(bool Authenticated, AuthUserResponse? User);
+
+    private sealed record AuthUserResponse(string UserId, string DisplayName, string? Email, string Provider);
+
+    private sealed record ErrorResponse(string Message);
+
+    public sealed record PasswordLoginRequest(string Email, string Password);
+}

--- a/src/BffGateway/BffGateway.Service/Auth/AuthPrincipalFactory.cs
+++ b/src/BffGateway/BffGateway.Service/Auth/AuthPrincipalFactory.cs
@@ -1,0 +1,53 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace BffGateway.Service.Auth;
+
+public static class AuthPrincipalFactory
+{
+    public const string ProviderClaimType = "textrpg:auth_provider";
+    public const string ProviderSubjectClaimType = "textrpg:provider_subject";
+
+    public static ClaimsPrincipal CreateBootstrapPrincipal(BffAuthOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Bootstrap.Email))
+        {
+            throw new InvalidOperationException("Bootstrap email is not configured.");
+        }
+
+        var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme);
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, $"bootstrap:{options.Bootstrap.Email.ToLowerInvariant()}"));
+        identity.AddClaim(new Claim(ClaimTypes.Name, options.Bootstrap.DisplayName));
+        identity.AddClaim(new Claim(ClaimTypes.Email, options.Bootstrap.Email));
+        identity.AddClaim(new Claim(ProviderClaimType, BffAuthOptions.PasswordProvider));
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    public static ClaimsPrincipal CreateExternalPrincipal(ClaimsPrincipal externalPrincipal, string provider)
+    {
+        var subject = externalPrincipal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? externalPrincipal.FindFirstValue("sub")
+            ?? throw new InvalidOperationException($"OAuth provider '{provider}' did not return a subject identifier.");
+
+        var email = externalPrincipal.FindFirstValue(ClaimTypes.Email)
+            ?? externalPrincipal.FindFirstValue("email");
+        var displayName = externalPrincipal.FindFirstValue(ClaimTypes.Name)
+            ?? externalPrincipal.FindFirstValue("name")
+            ?? email
+            ?? $"{provider} user";
+
+        var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme);
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, $"{provider}:{subject}"));
+        identity.AddClaim(new Claim(ClaimTypes.Name, displayName));
+        identity.AddClaim(new Claim(ProviderClaimType, provider));
+        identity.AddClaim(new Claim(ProviderSubjectClaimType, subject));
+
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Email, email));
+        }
+
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/BffGateway/BffGateway.Service/Auth/BffAuthOptions.cs
+++ b/src/BffGateway/BffGateway.Service/Auth/BffAuthOptions.cs
@@ -1,0 +1,148 @@
+namespace BffGateway.Service.Auth;
+
+public sealed class BffAuthOptions
+{
+    public const string PasswordProvider = "password";
+    public const string GoogleProvider = "google";
+    public const string MicrosoftProvider = "microsoft";
+
+    public string FrontendUrl { get; init; } = "http://localhost:5173";
+    public string[] AllowedOrigins { get; init; } = ["http://localhost:5173"];
+    public string SessionCookieName { get; init; } = "TextRpg.Auth";
+    public BootstrapCredentialOptions Bootstrap { get; init; } = new();
+    public OAuthProviderOptions Google { get; init; } = new();
+    public OAuthProviderOptions Microsoft { get; init; } = new();
+
+    public bool IsPasswordLoginEnabled =>
+        !string.IsNullOrWhiteSpace(Bootstrap.Email) &&
+        !string.IsNullOrWhiteSpace(Bootstrap.Password);
+
+    public IReadOnlyList<OAuthProviderDescriptor> EnabledOAuthProviders
+    {
+        get
+        {
+            var providers = new List<OAuthProviderDescriptor>();
+
+            if (Google.IsConfigured)
+            {
+                providers.Add(new OAuthProviderDescriptor(GoogleProvider, Google.DisplayName));
+            }
+
+            if (Microsoft.IsConfigured)
+            {
+                providers.Add(new OAuthProviderDescriptor(MicrosoftProvider, Microsoft.DisplayName));
+            }
+
+            return providers;
+        }
+    }
+
+    public static BffAuthOptions FromConfiguration(IConfiguration configuration)
+    {
+        var frontendUrl = configuration["AUTH_FRONTEND_URL"];
+        if (string.IsNullOrWhiteSpace(frontendUrl))
+        {
+            frontendUrl = "http://localhost:5173";
+        }
+
+        if (!Uri.TryCreate(frontendUrl, UriKind.Absolute, out var frontendUri))
+        {
+            throw new InvalidOperationException("AUTH_FRONTEND_URL must be an absolute URL.");
+        }
+
+        var allowedOrigins = configuration["AUTH_ALLOWED_ORIGINS"]?
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        allowedOrigins ??= [frontendUri.GetLeftPart(UriPartial.Authority)];
+
+        foreach (var origin in allowedOrigins)
+        {
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out _))
+            {
+                throw new InvalidOperationException($"AUTH_ALLOWED_ORIGINS contains an invalid absolute URL: {origin}");
+            }
+        }
+
+        return new BffAuthOptions
+        {
+            FrontendUrl = frontendUri.ToString().TrimEnd('/'),
+            AllowedOrigins = allowedOrigins,
+            SessionCookieName = configuration["AUTH_SESSION_COOKIE_NAME"] ?? "TextRpg.Auth",
+            Bootstrap = new BootstrapCredentialOptions
+            {
+                Email = configuration["AUTH_BOOTSTRAP_EMAIL"],
+                Password = configuration["AUTH_BOOTSTRAP_PASSWORD"],
+                DisplayName = configuration["AUTH_BOOTSTRAP_DISPLAY_NAME"] ?? "Bootstrap User"
+            },
+            Google = new OAuthProviderOptions
+            {
+                ClientId = configuration["AUTH_GOOGLE_CLIENT_ID"],
+                ClientSecret = configuration["AUTH_GOOGLE_CLIENT_SECRET"],
+                DisplayName = configuration["AUTH_GOOGLE_DISPLAY_NAME"] ?? "Google"
+            },
+            Microsoft = new OAuthProviderOptions
+            {
+                ClientId = configuration["AUTH_MICROSOFT_CLIENT_ID"],
+                ClientSecret = configuration["AUTH_MICROSOFT_CLIENT_SECRET"],
+                DisplayName = configuration["AUTH_MICROSOFT_DISPLAY_NAME"] ?? "Microsoft"
+            }
+        };
+    }
+
+    public bool TryGetOAuthProvider(string provider, out OAuthProviderDescriptor descriptor)
+    {
+        descriptor = EnabledOAuthProviders.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, provider, StringComparison.OrdinalIgnoreCase))
+            ?? new OAuthProviderDescriptor(string.Empty, string.Empty);
+
+        return !string.IsNullOrWhiteSpace(descriptor.Id);
+    }
+
+    public string BuildFrontendRedirect(string returnPath, IReadOnlyDictionary<string, string?> query)
+    {
+        var sanitizedPath = SanitizeReturnPath(returnPath);
+        var builder = new UriBuilder($"{FrontendUrl}{sanitizedPath}");
+
+        var queryPairs = query
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Value))
+            .Select(entry => $"{Uri.EscapeDataString(entry.Key)}={Uri.EscapeDataString(entry.Value!)}");
+
+        builder.Query = string.Join("&", queryPairs);
+        return builder.Uri.ToString();
+    }
+
+    public static string SanitizeReturnPath(string? returnPath)
+    {
+        if (string.IsNullOrWhiteSpace(returnPath))
+        {
+            return "/";
+        }
+
+        if (!returnPath.StartsWith("/", StringComparison.Ordinal))
+        {
+            return "/";
+        }
+
+        return returnPath;
+    }
+}
+
+public sealed class BootstrapCredentialOptions
+{
+    public string? Email { get; init; }
+    public string? Password { get; init; }
+    public string DisplayName { get; init; } = "Bootstrap User";
+}
+
+public sealed class OAuthProviderOptions
+{
+    public string? ClientId { get; init; }
+    public string? ClientSecret { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(ClientId) &&
+        !string.IsNullOrWhiteSpace(ClientSecret);
+}
+
+public sealed record OAuthProviderDescriptor(string Id, string DisplayName);

--- a/src/BffGateway/BffGateway.Service/Auth/BffAuthenticationExtensions.cs
+++ b/src/BffGateway/BffGateway.Service/Auth/BffAuthenticationExtensions.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.AspNetCore.Authentication.OAuth;
+
+namespace BffGateway.Service.Auth;
+
+public static class BffAuthenticationExtensions
+{
+    public static IServiceCollection AddBffAuthentication(this IServiceCollection services, BffAuthOptions authOptions)
+    {
+        var authentication = services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        authentication.AddCookie(options =>
+        {
+            options.Cookie.Name = authOptions.SessionCookieName;
+            options.Cookie.HttpOnly = true;
+            options.Cookie.IsEssential = true;
+            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            options.SlidingExpiration = true;
+            options.ExpireTimeSpan = TimeSpan.FromHours(12);
+            options.Events = new CookieAuthenticationEvents
+            {
+                OnRedirectToLogin = context =>
+                {
+                    if (context.Request.Path.StartsWithSegments("/api"))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        return Task.CompletedTask;
+                    }
+
+                    context.Response.Redirect(context.RedirectUri);
+                    return Task.CompletedTask;
+                },
+                OnRedirectToAccessDenied = context =>
+                {
+                    if (context.Request.Path.StartsWithSegments("/api"))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                        return Task.CompletedTask;
+                    }
+
+                    context.Response.Redirect(context.RedirectUri);
+                    return Task.CompletedTask;
+                }
+            };
+        });
+
+        if (authOptions.Google.IsConfigured)
+        {
+            authentication.AddGoogle(BffAuthOptions.GoogleProvider, options =>
+            {
+                options.ClientId = authOptions.Google.ClientId!;
+                options.ClientSecret = authOptions.Google.ClientSecret!;
+                options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.Events = BuildOAuthEvents(BffAuthOptions.GoogleProvider);
+            });
+        }
+
+        if (authOptions.Microsoft.IsConfigured)
+        {
+            authentication.AddMicrosoftAccount(BffAuthOptions.MicrosoftProvider, options =>
+            {
+                options.ClientId = authOptions.Microsoft.ClientId!;
+                options.ClientSecret = authOptions.Microsoft.ClientSecret!;
+                options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.Events = BuildOAuthEvents(BffAuthOptions.MicrosoftProvider);
+            });
+        }
+
+        services.AddAuthorization();
+        return services;
+    }
+
+    private static Func<RemoteFailureContext, Task> BuildRemoteFailureHandler(string provider)
+    {
+        return context =>
+        {
+            var returnPath = context.Properties?.Items.TryGetValue("returnUrl", out var configuredReturnUrl) == true
+                ? configuredReturnUrl
+                : "/";
+            var message = context.Failure?.Message ?? "OAuth authentication failed.";
+            var target = $"/api/auth/oauth/error?provider={Uri.EscapeDataString(provider)}&returnUrl={Uri.EscapeDataString(returnPath ?? "/")}&message={Uri.EscapeDataString(message)}";
+
+            context.Response.Redirect(target);
+            context.HandleResponse();
+            return Task.CompletedTask;
+        };
+    }
+
+    private static OAuthEvents BuildOAuthEvents(string provider)
+    {
+        return new OAuthEvents
+        {
+            OnCreatingTicket = context =>
+            {
+                context.Identity?.AddClaim(new Claim(AuthPrincipalFactory.ProviderClaimType, provider));
+                return Task.CompletedTask;
+            },
+            OnTicketReceived = context =>
+            {
+                context.Principal = AuthPrincipalFactory.CreateExternalPrincipal(context.Principal!, provider);
+                return Task.CompletedTask;
+            },
+            OnRemoteFailure = BuildRemoteFailureHandler(provider)
+        };
+    }
+}

--- a/src/BffGateway/BffGateway.Service/Auth/BootstrapPasswordLoginService.cs
+++ b/src/BffGateway/BffGateway.Service/Auth/BootstrapPasswordLoginService.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BffGateway.Service.Auth;
+
+public sealed class BootstrapPasswordLoginService(BffAuthOptions options)
+{
+    public bool IsEnabled => options.IsPasswordLoginEnabled;
+
+    public bool Validate(string email, string password)
+    {
+        if (!IsEnabled || string.IsNullOrWhiteSpace(options.Bootstrap.Email) || string.IsNullOrWhiteSpace(options.Bootstrap.Password))
+        {
+            return false;
+        }
+
+        if (!string.Equals(email.Trim(), options.Bootstrap.Email, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes(password));
+        var configuredHash = SHA256.HashData(Encoding.UTF8.GetBytes(options.Bootstrap.Password));
+
+        return CryptographicOperations.FixedTimeEquals(providedHash, configuredHash);
+    }
+}

--- a/src/BffGateway/BffGateway.Service/BffGateway.Service.csproj
+++ b/src/BffGateway/BffGateway.Service/BffGateway.Service.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
   </ItemGroup>
 

--- a/src/BffGateway/BffGateway.Service/Program.cs
+++ b/src/BffGateway/BffGateway.Service/Program.cs
@@ -1,13 +1,34 @@
+using BffGateway.Service.Auth;
 using BffGateway.Service.Services;
 using TextRpg.Shared.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
+var authOptions = BffAuthOptions.FromConfiguration(builder.Configuration);
 
+builder.AddTextRpgTelemetry();
 builder.Services.AddGrpc(options => options.EnableDetailedErrors = builder.Environment.IsDevelopment());
+builder.Services.AddSingleton(authOptions);
+builder.Services.AddSingleton<BootstrapPasswordLoginService>();
+builder.Services.AddBffAuthentication(authOptions);
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("frontend", policy =>
+    {
+        policy.WithOrigins(authOptions.AllowedOrigins)
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
 
 var app = builder.Build();
 
+app.UseCors("frontend");
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapGrpcService<GameApiGrpcService>();
+app.MapAuthEndpoints();
 app.MapFoundationEndpoints("bffgateway");
 
 app.Run();

--- a/src/BffGateway/BffGateway.Service/appsettings.Development.json
+++ b/src/BffGateway/BffGateway.Service/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http1AndHttp2"
+    }
   }
 }

--- a/src/BffGateway/BffGateway.Service/appsettings.json
+++ b/src/BffGateway/BffGateway.Service/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "Kestrel": {
     "EndpointDefaults": {
-      "Protocols": "Http2"
+      "Protocols": "Http1AndHttp2"
     }
   }
 }

--- a/src/CoreBackend/CoreBackend.Service/Program.cs
+++ b/src/CoreBackend/CoreBackend.Service/Program.cs
@@ -3,6 +3,7 @@ using TextRpg.Shared.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddTextRpgTelemetry();
 builder.Services.AddGrpc(options => options.EnableDetailedErrors = builder.Environment.IsDevelopment());
 
 var app = builder.Build();

--- a/src/Jobs/Jobs.Service/Program.cs
+++ b/src/Jobs/Jobs.Service/Program.cs
@@ -1,5 +1,8 @@
+using TextRpg.Shared.Utils;
+
 var builder = Host.CreateApplicationBuilder(args);
 
+builder.AddTextRpgTelemetry();
 // TODO: Add Hangfire configuration
 // TODO: Add job handlers
 

--- a/src/LocalGateway/LocalGateway.Service/Program.cs
+++ b/src/LocalGateway/LocalGateway.Service/Program.cs
@@ -1,5 +1,8 @@
+using TextRpg.Shared.Utils;
+
 var builder = Host.CreateApplicationBuilder(args);
 
+builder.AddTextRpgTelemetry();
 // TODO: Add gRPC client configuration for bidirectional streaming
 // TODO: Add work stream client service
 

--- a/src/Shared/Utils/Shared.Utils.csproj
+++ b/src/Shared/Utils/Shared.Utils.csproj
@@ -10,4 +10,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/Utils/TelemetryDefaultsExtensions.cs
+++ b/src/Shared/Utils/TelemetryDefaultsExtensions.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace TextRpg.Shared.Utils;
+
+public static class TelemetryDefaultsExtensions
+{
+    public static TBuilder AddTextRpgTelemetry<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        var serviceName = builder.Environment.ApplicationName;
+        var hasOtlpEndpoint =
+            !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]) ||
+            !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]) ||
+            !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]) ||
+            !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]);
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(serviceName))
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+
+                if (hasOtlpEndpoint)
+                {
+                    tracing.AddOtlpExporter();
+                }
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+
+                if (hasOtlpEndpoint)
+                {
+                    metrics.AddOtlpExporter();
+                }
+            });
+
+        builder.Logging.AddOpenTelemetry();
+        builder.Services.Configure<OpenTelemetryLoggerOptions>(options =>
+        {
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+            options.ParseStateValues = true;
+
+            if (hasOtlpEndpoint)
+            {
+                options.AddOtlpExporter();
+            }
+        });
+
+        return builder;
+    }
+}


### PR DESCRIPTION
## Summary
- add bootstrap email/password auth and Google/Microsoft OAuth support in the BFF and frontend
- wire the frontend into Aspire, add OpenTelemetry defaults, and fix Coder/iPad auth UI issues
- add GitHub Actions + Kubernetes deployment assets for the text-rpg namespace on dev-cluster with frontend host text-rpg.dev.sakuraya.cloud

## Validation
- dotnet build TextRpg.slnx --configuration Release
- dotnet test TextRpg.slnx --configuration Release
- cd frontend && npm run build
- dotnet aspire run --apphost src/AppHost/AppHost.csproj --non-interactive --detach --format json